### PR TITLE
Static page contents may be configured outside the source code.

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,8 @@ class ArticlesController < ApplicationController
   def index
     @search = ArticleSearch.new(params)
     @list = @search.result.includes(:contributors, :periodical, :month).periodical_order.contents_order.paginate(page: params[:page], :per_page => 20)
-    @contents = PageContent.where(:page_key => 'home').first
+    page_contents = PageContent.where(:page_key => 'home').first
+    @contents = page_contents ? page_contents.html : nil
   end
 
   def test

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,6 +2,7 @@ class ArticlesController < ApplicationController
   def index
     @search = ArticleSearch.new(params)
     @list = @search.result.includes(:contributors, :periodical, :month).periodical_order.contents_order.paginate(page: params[:page], :per_page => 20)
+    @contents = PageContent.where(:page_key => 'home').first
   end
 
   def test

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -17,10 +17,7 @@ class StaticPagesController < ApplicationController
     @contact = Contact.first
   end
   
-  def show
-    
-  end
-  
+ 
   def load_contents(page_key = nil)
     @contents = nil
     @page_key = page_key || params[:page_key]

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,14 +1,31 @@
 class StaticPagesController < ApplicationController
+  before_action :load_contents
   def history
+    load_contents('history')
   end
 
   def sites
+    load_contents('sites')
   end
 
   def scholarship
+    load_contents('scholarship')
   end
 
   def contact
+    load_contents('contact')
     @contact = Contact.first
+  end
+  
+  def show
+    
+  end
+  
+  def load_contents(page_key = nil)
+    @contents = nil
+    @page_key = page_key || params[:page_key]
+    if @page_key
+      @contents = PageContent.where(:page_key => @page_key).first
+    end    
   end
 end

--- a/app/models/page_content.rb
+++ b/app/models/page_content.rb
@@ -1,0 +1,2 @@
+class PageContent < ActiveRecord::Base
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -126,11 +126,14 @@
       <br><br><br>
       <div class="panel panel-default">
         <div class="panel-body">
-          <p>Welcome to the Curran Index, a reference project whose mission is to identify the men and women whose stories, poems, and articles appeared anonymously in 19th-century British periodicals. The index is named after Eileen Curran, one of the original editors of the ground-breaking Wellesley Index to Victorian Periodicals. Eileen continued her dedicated life-long pursuit of attribution scholarship well into the 21st century. In 2002 Patrick Leary brought her body of work to the web through his Victorian Research Web; for the ensuing decade and a half Patrick has encouraged and supported attribution scholarship, published updates, and kept this information accessible. After Eileen’s death in 2013, he recruited a new editor to continue the project.</p>
-          <p>Now, with a thank you to Patrick, and with the generous support of the Research Society for Victorian Periodicals, this ever-growing body of data -- currently encompassing over 16,000 articles, more than 2,000 contributors, and an enhanced range of periodicals – is reintroduced in a new format, as a still freely accessible and now fully searchable database. There are many surprises and intriguing clues to be found in the Curran Index, and I invite you to enjoy and explore them to your heart's content.  I also invite you to get in touch with me with any questions or comments, and especially to let me know about your own researches into the identities of anonymous Victorian contributors to the periodical press.</p>
-          <p><%=mail_to "#{Contact.first.email}", "Gary Simons"%><br>
-          Editor, Curran Index</p>
-
+          <% if @contents %>
+          <%= raw(@contents) %>
+          <% else %>
+            <p>Welcome to the Curran Index, a reference project whose mission is to identify the men and women whose stories, poems, and articles appeared anonymously in 19th-century British periodicals. The index is named after Eileen Curran, one of the original editors of the ground-breaking Wellesley Index to Victorian Periodicals. Eileen continued her dedicated life-long pursuit of attribution scholarship well into the 21st century. In 2002 Patrick Leary brought her body of work to the web through his Victorian Research Web; for the ensuing decade and a half Patrick has encouraged and supported attribution scholarship, published updates, and kept this information accessible. After Eileen’s death in 2013, he recruited a new editor to continue the project.</p>
+            <p>Now, with a thank you to Patrick, and with the generous support of the Research Society for Victorian Periodicals, this ever-growing body of data -- currently encompassing over 16,000 articles, more than 2,000 contributors, and an enhanced range of periodicals – is reintroduced in a new format, as a still freely accessible and now fully searchable database. There are many surprises and intriguing clues to be found in the Curran Index, and I invite you to enjoy and explore them to your heart's content.  I also invite you to get in touch with me with any questions or comments, and especially to let me know about your own researches into the identities of anonymous Victorian contributors to the periodical press.</p>
+            <p><%=mail_to "#{Contact.first.email}", "Gary Simons"%><br>
+            Editor, Curran Index</p>
+          <% end %>  
         </div>
       </div>
     <% else %>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,5 +1,9 @@
+<% if @contents%>
+<%= raw(@contents.html) %>
+<% else %>
 <div class="col-sm-10 col-sm-offset-1">
   <h4 class="center">Contact</h4><br>
   <p class="center">Questions and inquiries on the Curran Index and its website can be directed to <%=mail_to "#{@contact.email}", "Gary Simons"%>, <%=@contact.email%>.</p>
 
 </div>
+<% end %>

--- a/app/views/static_pages/history.html.erb
+++ b/app/views/static_pages/history.html.erb
@@ -1,3 +1,6 @@
+<% if @contents%>
+<%= raw(@contents.html) %>
+<% else %>
 <div class="col-sm-10 col-sm-offset-1">
   <h4 class="center">History of the Curran Index</h4>
 
@@ -13,3 +16,4 @@
   Editor, Curran Index</p>
   <br>
 </div>
+<% end %>

--- a/app/views/static_pages/scholarship.html.erb
+++ b/app/views/static_pages/scholarship.html.erb
@@ -1,3 +1,6 @@
+<% if @contents%>
+<%= raw(@contents.html) %>
+<% else %>
 <div class="col-sm-10 col-sm-offset-1">
 
 <h4 class="center">Attribution Scholarship in the Curran Index</h4>
@@ -20,3 +23,4 @@
 <p>It should also be noted that sometimes, even when an article signature or a publisher’s record connects a name with a given article, the article may still be effectively anonymous. Outside of other information, who would know, for example, what to make of a “J. Smith” associated with a particular article? Our position is that the curtain of anonymity has not been fully pierced until some descriptive matter can be attached to a name. A great deal of effort has been made, using tools such as Frederick Boase’s Modern English Biography and digital tools such as the genealogical website FamilySearch, the British Newspaper Archive, and Worldcat, to attach some meat to the bones of otherwise unrecognized names. In essence, we regard attributions as incomplete until information such as life dates, occupation, nationality, education, or other writings can make attributions more meaningful.</p>
 <br>
 </div>
+<% end %>

--- a/app/views/static_pages/sites.html.erb
+++ b/app/views/static_pages/sites.html.erb
@@ -1,3 +1,6 @@
+<% if @contents%>
+<%= raw(@contents.html) %>
+<% else %>
 <div class="col-sm-10 col-sm-offset-1">
 <h4 class="center">Other freely accessible sites on contributors to 19th Century British Periodicals</h4>
 <br>
@@ -20,3 +23,4 @@
 <p><b>The Victoria Research Web</b>, a guide to research resources for the study of 19th- century Britain, established and maintained by Patrick Leary. For 15 years this site has been the primary home of the Curran Index  <%=link_to "http://victorianresearch.org/", "http://victorianresearch.org/", target: "_blank"%></p>
 <br>
 </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get 'date_range' => 'articles#date_range'
   get 'title_search' => 'articles#title_search'
 
-  get 'static/:page_key' => 'static_pages#show'
+#  get 'static/:page_key' => 'static_pages#show'
 
 #  get '/contributor' => 'articles#contributor', as: :contributor
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get 'date_range' => 'articles#date_range'
   get 'title_search' => 'articles#title_search'
 
+  get 'static/:page_key' => 'static_pages#show'
+
 #  get '/contributor' => 'articles#contributor', as: :contributor
 
   resources :essays, only: [:index]

--- a/db/migrate/20180419234556_create_page_contents.rb
+++ b/db/migrate/20180419234556_create_page_contents.rb
@@ -1,0 +1,10 @@
+class CreatePageContents < ActiveRecord::Migration
+  def change
+    create_table :page_contents do |t|
+      t.string :page_key
+      t.text :html
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 1) do
+ActiveRecord::Schema.define(version: 20180419234556) do
 
   create_table "articles", force: :cascade do |t|
     t.integer "periodical_id",          limit: 4
@@ -84,6 +84,13 @@ ActiveRecord::Schema.define(version: 1) do
   create_table "notes", force: :cascade do |t|
     t.string "source",      limit: 255
     t.text   "information", limit: 4294967295
+  end
+
+  create_table "page_contents", force: :cascade do |t|
+    t.string   "page_key",   limit: 255
+    t.text     "html",       limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   create_table "periodicals", force: :cascade do |t|


### PR DESCRIPTION
The system now supports database-driven page contents for the following
"static" pages:

* Attribution Scholarship (`scholarship`)
* History (`history`)
* Contact Us (`contact`)
* Related Sites (`sites`)

In order to support this, a new database table called `page_contents`
has been created according to the following schema:
```
+------------+--------------+------+-----+---------+----------------+
| Field      | Type         | Null | Key | Default | Extra          |
+------------+--------------+------+-----+---------+----------------+
| id         | int(11)      | NO   | PRI | NULL    | auto_increment |
| page_key   | varchar(255) | YES  |     | NULL    |                |
| html       | text         | YES  |     | NULL    |                |
| created_at | datetime     | NO   |     | NULL    |                |
| updated_at | datetime     | NO   |     | NULL    |                |
+------------+--------------+------+-----+---------+----------------+
```

Of these fields, the meaningful ones are
* `page_key` is the key to a page in the URL.  Currently valid page keys
are `scholarship`, `history`, `contact`, and `sites`, however this can be
expanded flexibly.
* `html` is the HTML source code for the page.

If no page contents record is found for an existing page key, the
static text in the Github repository for that page is used instead.